### PR TITLE
Update deps and keytest

### DIFF
--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -23,7 +23,7 @@ function extractStrings(keyTest, jsonStr) {
     if (typeof val === 'object' || Array.isArray(val)) {
       pushDotKeys(key, val, queue);
     }
-    if (typeof val === 'string' && val !== '' && keyTest(key)) {
+    if (typeof val === 'string' && val !== '' && keyTest(key, obj)) {
       strings.push(val);
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "Justin van der Merwe (https://github.com/justinvdm)",
     "Andris Reinman <andris.reinman@gmail.com> (http://www.andrisreinman.com)",
     "Michael Weibel (https://github.com/mweibel)",
-
     "Yasu <mahata777@gmail.com> (https://github.com/mahata)",
     "Marcus (https://github.com/mphasize)"
   ],
@@ -41,16 +40,16 @@
   "preferGlobal": true,
   "dependencies": {
     "acorn": "^0.11.0",
-    "gettext-parser": "^1.1.0",
     "commander": "2.5.0",
+    "escape-string-regexp": "1.0.1",
+    "gettext-parser": "^1.1.0",
+    "gulp-static-i18n": "0.0.5",
     "jade": "0.30.0",
-    "escape-string-regexp": "1.0.1"
+    "lodash": "^3.5.0"
   },
   "devDependencies": {
-    "gulp-static-i18n": "0.0.4",
     "i18n-abide": "0.0.17",
     "jshint": "2.5.5",
-    "lodash": "^3.5.0",
     "test": "*"
   },
   "scripts": {


### PR DESCRIPTION
- 'gulp-static-i18n' and 'lodash' need to be added as dependencies, not devDependencies
- keytest now supports a limited amount of value checks to determine if a json key requires extraction (and thus the obj is passed)
