### PR TITLE
Bump gulp-static-i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Yola Changes](https://github.com/yola/jsxgettext/releases)
 
+## 0.9.0-yola1
+
+* Bump gulp-static-i18n allowing dotted json keys to be translated [#6][]
+
+[#6]: https://github.com/yola/jsxgettext/pull/6
+
 
 ## 0.6.3-yola2
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "commander": "^2.9.0",
     "escape-string-regexp": "^1.0.4",
     "gettext-parser": "^1.1.2",
-    "gulp-static-i18n": "0.0.5",
+    "gulp-static-i18n": "0.1.0",
     "jade": "^1.11.0",
     "lodash": "^3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Marcus (https://github.com/mphasize)"
   ],
   "name": "jsxgettext",
-  "version": "0.9.0",
+  "version": "0.9.0-yola1",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jade, Jinja and Handlebars files.",
   "keywords": [


### PR DESCRIPTION
Adding support for translation of json with dotted keys.
eg {"a.b.c":"val"}