### PR TITLE
Update Acorn & Fix JSXText visitor

### DIFF
--- a/lib/jsxgettext.js
+++ b/lib/jsxgettext.js
@@ -7,8 +7,9 @@
 var fs   = require('fs');
 var path = require('path');
 
-var parser = require('acorn-jsx');
-var walk = require('acorn/dist/walk');
+var acorn = require('acorn');
+var acornJSX = require('acorn-jsx');
+var walk = require('acorn-walk');
 var gettextParser = require('gettext-parser');
 var regExpEscape  = require('escape-string-regexp');
 
@@ -39,7 +40,8 @@ var walkBase = Object.assign({}, walk.base, {
     c(node.expression, st);
   },
 
-  JSXEmptyExpression: function () {}
+  JSXEmptyExpression: function () {},
+  JSXText: function () {}
 });
 
 function isStringLiteral(node) {
@@ -186,8 +188,8 @@ function parse(sources, options) {
 
     var source   = sources[filename].replace(/^#.*/, ''); // strip leading hash-bang
     var astComments = [];
+    var parser = acorn.Parser.extend(acornJSX());
     var ast      = parser.parse(source, {
-      ecmaVersion: 6,
       sourceType: 'module',
       plugins: { jsx: { allowNamespaces: false } },
       onComment: function (block, text, start, end, line/*, column*/) {

--- a/package.json
+++ b/package.json
@@ -43,12 +43,13 @@
   "bin": "lib/cli.js",
   "preferGlobal": true,
   "engineStrict": true,
-    "engines": {
-      "node": ">= 4.0.0"
+  "engines": {
+    "node": ">= 4.0.0"
   },
   "dependencies": {
-    "acorn-jsx": "^3.0.0",
-    "acorn": "^3.0.0",
+    "acorn": "^7.1.0",
+    "acorn-jsx": "^5.1.0",
+    "acorn-walk": "^7.0.0",
     "commander": "^2.9.0",
     "escape-string-regexp": "^1.0.4",
     "gettext-parser": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Marcus (https://github.com/mphasize)"
   ],
   "name": "@yola/jsxgettext",
-  "version": "0.9.0-yola1",
+  "version": "0.9.0-yola2",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jade, Jinja and Handlebars files.",
   "keywords": [


### PR DESCRIPTION
We need `jsxgettext` to support modern ECMAScript syntax to extract `gettext` messages.