### PR TITLE
Replaced `jade` with `pug` in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Yola Changes](https://github.com/yola/jsxgettext/releases)
 
+## 0.9.2-yola1
+
+* Replaced `jade` with `pug` in dependencies in package.json(since the `jade` library changed its name to `pug`)
+
+[#12]: https://github.com/yola/jsxgettext/pull/12
+
 ## 0.9.1-yola1
 
 * Remove `lodash` from library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Replaced `jade` with `pug` in dependencies in package.json(since the `jade` library changed its name to `pug`)
 
-[#12]: https://github.com/yola/jsxgettext/pull/12
+[#13]: https://github.com/yola/jsxgettext/pull/13
 
 ## 0.9.1-yola1
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Marcus (https://github.com/mphasize)"
   ],
   "name": "@yola/jsxgettext",
-  "version": "0.9.1-yola1",
+  "version": "0.9.2-yola1",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jade, Jinja and Handlebars files.",
   "keywords": [
@@ -54,7 +54,7 @@
     "escape-string-regexp": "^1.0.4",
     "gettext-parser": "^1.1.2",
     "gulp-static-i18n": "0.1.0",
-    "jade": "^1.11.0"
+    "pug": "3.0.3"
   },
   "devDependencies": {
     "i18n-abide": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "devDependencies": {
     "i18n-abide": "0.0.17",
     "jshint": "2.5.5",
-    "lodash": "^3.5.0",
     "test": "*"
   },
   "scripts": {


### PR DESCRIPTION
part of: https://github.com/yola/production/issues/14511
