### PR TITLE
Bump up `gulp-static-i18n` to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 [Yola Changes](https://github.com/yola/jsxgettext/releases)
 
 
+## 1.0.2-yola1
+
+* Bump up `gulp-static-i18n` to 1.0.1
+
 ## 1.0.1-yola1
 
 * Bump up `gulp-static-i18n` to 1.0.0

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Marcus (https://github.com/mphasize)"
   ],
   "name": "@yola/jsxgettext",
-  "version": "1.0.1-yola1",
+  "version": "1.0.2-yola1-rc.les.0",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jinja and Handlebars files.",
   "keywords": [
@@ -53,7 +53,7 @@
     "commander": "^2.9.0",
     "escape-string-regexp": "^1.0.4",
     "gettext-parser": "^1.1.2",
-    "gulp-static-i18n": "1.0.0"
+    "gulp-static-i18n": "1.0.1-rc.les.0"
   },
   "devDependencies": {
     "i18n-abide": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "commander": "^2.9.0",
     "escape-string-regexp": "^1.0.4",
     "gettext-parser": "^1.1.2",
-    "gulp-static-i18n": "1.0.1-rc.les.0"
+    "gulp-static-i18n": "1.0.1"
   },
   "devDependencies": {
     "i18n-abide": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Marcus (https://github.com/mphasize)"
   ],
   "name": "@yola/jsxgettext",
-  "version": "1.0.2-yola1-rc.les.0",
+  "version": "1.0.2-yola1",
   "license": "MPL-2.0",
   "description": "Extracts gettext strings from JavaScript, EJS, Jinja and Handlebars files.",
   "keywords": [


### PR DESCRIPTION
part of: https://github.com/yola/production/issues/14665
